### PR TITLE
Move deployed sha above /:user so it is actually picked by sinatra

### DIFF
--- a/lib/travis/lite/application.rb
+++ b/lib/travis/lite/application.rb
@@ -44,8 +44,7 @@ module Travis
         mustache :repositories
       end
 
-      get '/deployed-sha' do
-        content_type :text
+      get '/deployed-sha', provides: :txt do
         `git rev-parse HEAD`
       end
 

--- a/lib/travis/lite/application.rb
+++ b/lib/travis/lite/application.rb
@@ -44,6 +44,11 @@ module Travis
         mustache :repositories
       end
 
+      get '/deployed-sha' do
+        content_type :text
+        `git rev-parse HEAD`
+      end
+
       get '/:user/?' do |user|
         @repositories = RepositoryFetcher.fetch_with_owner_name(user)
         @title = "#{user}'s repositories"
@@ -56,11 +61,6 @@ module Travis
         @repository = RepositoryFetcher.fetch_with_slug(slug)
         @builds = BuildFetcher.fetch_recent_for_slug(slug)
         mustache :repository
-      end
-
-      get '/deployed-sha' do
-        content_type :text
-        `git rev-parse HEAD`
       end
 
       error do


### PR DESCRIPTION
Makes /deployed-sha work locally.

It will still not work on Heroku, as Heroku doesn't keep .git afaik.
