### PR TITLE
Mark last build as finished if last_build_finished_at is set.

### DIFF
--- a/lib/travis/lite/models/repository.rb
+++ b/lib/travis/lite/models/repository.rb
@@ -23,7 +23,7 @@ module Travis
         end
 
         def last_build_finished?
-          @data['last_build_status'] == 0
+          !!@data['last_build_finished_at']
         end
 
         def last_build_passed?


### PR DESCRIPTION
Before this commit some builds have been marked as "Running" although they failed.
See http://travis-lite.com/splattael `minitest` and `libnotify`.

After this commit theses builds are correctly marked as "Failed".
