### PR TITLE
Allow repository names to contain dots.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,11 +24,16 @@ class OwnerNameContraint
   end
 end
 
+REPOSITORY_NAME_REGEXP = %r{[^/]+}
+
 TravisLite::Application.routes.draw do
   get "jobs/show"
-  resources :repositories, path: ':owner_name', only: %i[index show], param: :name, constraints: OwnerNameContraint do
-    resources :builds, only: %i[index show]
-    resources :jobs, only: %i[show]
+  resources :repositories, path: ':owner_name', only: :index, param: :name, constraints: OwnerNameContraint do
+    member do
+      get :show, name: REPOSITORY_NAME_REGEXP
+    end
+    resources :builds, only: %i[index show], repository_name: REPOSITORY_NAME_REGEXP
+    resources :jobs, only: %i[show], repository_name: REPOSITORY_NAME_REGEXP
   end
 
   root "repositories#index"

--- a/spec/routing/builds_routing_spec.rb
+++ b/spec/routing/builds_routing_spec.rb
@@ -10,6 +10,15 @@ describe "routing to builds" do
     )
   end
 
+  it "routes repository names containing dots correctly" do
+    expect(get: "/henrikhodne/davinci.rb/builds").to route_to(
+      controller: "builds",
+      action: "index",
+      owner_name: "henrikhodne",
+      repository_name: "davinci.rb",
+    )
+  end
+
   it "routes /henrikhodne/travis-lite/builds/12345 to builds#show" do
     expect(get: "/henrikhodne/travis-lite/builds/12345").to route_to(
       controller: "builds",

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -10,4 +10,14 @@ describe "routing to jobs" do
       id: "12345",
     )
   end
+
+  it "routes repository names containing dots correctly" do
+    expect(get: "/henrikhodne/davinci.rb/jobs/12345").to route_to(
+      controller: "jobs",
+      action: "show",
+      owner_name: "henrikhodne",
+      repository_name: "davinci.rb",
+      id: "12345",
+    )
+  end
 end

--- a/spec/routing/repositories_routing_spec.rb
+++ b/spec/routing/repositories_routing_spec.rb
@@ -25,6 +25,15 @@ describe "routing to repositories" do
     )
   end
 
+  it "routes repository names containing dots correctly" do
+    expect(get: "/henrikhodne/davinci.rb").to route_to(
+      controller: "repositories",
+      action: "show",
+      owner_name: "henrikhodne",
+      name: "davinci.rb",
+    )
+  end
+
   it "doesn't route /javascripts/application.js" do
     expect(get: "/javascripts/application.js").to_not be_routable
   end


### PR DESCRIPTION
Before this commit repository names which contain dots point
to wrong repositories.

Examples:
- http://travis-lite.com/henrikhodne/davinci.rb -> henrikhodne/davinci
- http://travis-lite.com/kytrinyx/exercism.io -> kytrinyx/exercism

Note that had to extract the show route as a member to make the regexp work.
It didn't work on `resources :repositories`.
